### PR TITLE
Fix grip in and grip out

### DIFF
--- a/robot_comm/include/robot_comm/robot_comm.h
+++ b/robot_comm/include/robot_comm/robot_comm.h
@@ -188,8 +188,8 @@ class RobotComm
 
     bool HandJogIn();
     bool HandJogOut();
-    bool HandGripIn();
-    bool HandGripOut();
+    bool HandGripIn(const double handForce);
+    bool HandGripOut(const double handForce);
     bool HandOnBlow();
     bool HandOffBlow();
     bool HandOnVacuum();

--- a/robot_comm/src/robot_comm.cpp
+++ b/robot_comm/src/robot_comm.cpp
@@ -802,13 +802,15 @@ bool RobotComm::HandStop()
   return handle_robot_HandStop.call(robot_HandStop_srv);
 }
 
-bool RobotComm::HandGripIn()
+bool RobotComm::HandGripIn(const double handForce)
 {
+  robot_HandGripIn_srv.request.handForce = handForce;
   return handle_robot_HandGripIn.call(robot_HandGripIn_srv);
 }
 
-bool RobotComm::HandGripOut()
+bool RobotComm::HandGripOut(const double handForce)
 {
+  robot_HandGripOut_srv.request.handForce = handForce;
   return handle_robot_HandGripOut.call(robot_HandGripOut_srv);
 }
 

--- a/robot_comm/src/robot_comm.h
+++ b/robot_comm/src/robot_comm.h
@@ -188,8 +188,8 @@ class RobotComm
 
     bool HandJogIn();
     bool HandJogOut();
-    bool HandGripIn();
-    bool HandGripOut();
+    bool HandGripIn(const double handForce);
+    bool HandGripOut(const double handForce);
     bool HandOnBlow();
     bool HandOffBlow();
     bool HandOnVacuum();

--- a/robot_comm/srv/robot_HandGripIn.srv
+++ b/robot_comm/srv/robot_HandGripIn.srv
@@ -1,5 +1,6 @@
-#Service to grip the Yumi hand in
+#Service to grip the Yumi hand in with certain amount of force
 
+float64 handForce
 ---
 int64 ret
 string msg

--- a/robot_comm/srv/robot_HandGripOut.srv
+++ b/robot_comm/srv/robot_HandGripOut.srv
@@ -1,5 +1,6 @@
-#Service to grip the Yumi hand out
+#Service to grip the Yumi hand out with certain amount of force
 
+float64 handForce
 ---
 int64 ret
 string msg

--- a/robot_node/ABBInterpreter/include/ABBInterpreter.h
+++ b/robot_node/ABBInterpreter/include/ABBInterpreter.h
@@ -47,8 +47,8 @@ namespace ABBInterpreter
   string handJogOut(int idCode=0);
   string handStop(int idCode=0);
   string handCalibrate(int idCode=0);
-  string handGripIn(int idCode=0);
-  string handGripOut(int idCode=0);
+  string handGripIn(double handForce, int idCode=0);
+  string handGripOut(double handForce, int idCode=0);
   string handOnBlow(int idCode=0);
   string handOffBlow(int idCode=0);
   string handOnVacuum(int idCode=0);

--- a/robot_node/ABBInterpreter/src/ABBInterpreter.cpp
+++ b/robot_node/ABBInterpreter/src/ABBInterpreter.cpp
@@ -368,14 +368,18 @@ string ABBInterpreter::handGetPose(int idCode)
   return stringFromInstructionCode(24,idCode);
 }
 
-string ABBInterpreter::handGripIn(int idCode)
+string ABBInterpreter::handGripIn(double handForce, int idCode)
 {
-  return stringFromInstructionCode(25,idCode);
+  string msg = stringFromInstructionCodeNoEnding(25,idCode);
+  sprintf(buff,"%08.1lf ",handForce);  msg += buff ;
+  return (msg+"#");
 }
 
-string ABBInterpreter::handGripOut(int idCode)
+string ABBInterpreter::handGripOut(double handForce, int idCode)
 {
-  return stringFromInstructionCode(26,idCode);
+  string msg = stringFromInstructionCodeNoEnding(26,idCode);
+  sprintf(buff,"%08.1lf ",handForce);  msg += buff ;
+  return (msg+"#");
 }
 
 string ABBInterpreter::handOnBlow(int idCode)

--- a/robot_node/src/robot_node.cpp
+++ b/robot_node/src/robot_node.cpp
@@ -1098,12 +1098,12 @@ SERVICE_CALLBACK_DEF(HandStop)
 
 SERVICE_CALLBACK_DEF(HandGripIn)
 {
-  return RUN_AND_RETURN_RESULT(handGripIn(), res.ret, res.msg, "Not able to grip hand in");
+  return RUN_AND_RETURN_RESULT(handGripIn(req.handForce), res.ret, res.msg, "ROBOT_CONTROLLER: Not able to grip hand in");
 }
 
 SERVICE_CALLBACK_DEF(HandGripOut)
 {
-  return RUN_AND_RETURN_RESULT(handGripOut(), res.ret, res.msg, "Not able to grip hand out");
+  return RUN_AND_RETURN_RESULT(handGripOut(req.handForce), res.ret, res.msg, "ROBOT_CONTROLLER: Not able to grip hand out");
 }
 
 SERVICE_CALLBACK_DEF(HandOnBlow)
@@ -1692,18 +1692,18 @@ bool RobotController::handStop()
 }
 
 // Grip In
-bool RobotController::handGripIn()
+bool RobotController::handGripIn(double handForce)
 {
   PREPARE_TO_TALK_TO_ROBOT
-  strcpy(message, ABBInterpreter::handGripIn(randNumber).c_str());
+  strcpy(message, ABBInterpreter::handGripIn(handForce, randNumber).c_str());
   SEND_MSG_TO_ROBOT_AND_END
 }
 
 // Grip Out
-bool RobotController::handGripOut()
+bool RobotController::handGripOut(double handForce)
 {
   PREPARE_TO_TALK_TO_ROBOT
-  strcpy(message, ABBInterpreter::handGripOut(randNumber).c_str());
+  strcpy(message, ABBInterpreter::handGripOut(handForce, randNumber).c_str());
   SEND_MSG_TO_ROBOT_AND_END
 }
 

--- a/robot_node/src/robot_node.h
+++ b/robot_node/src/robot_node.h
@@ -196,8 +196,6 @@ class RobotController
   bool handJogOut();
   bool handCalibrate();
   bool handStop();
-  bool handGripIn();
-  bool handGripOut();
   bool handOnBlow();
   bool handOffBlow();
   bool handOnVacuum();
@@ -327,6 +325,8 @@ class RobotController
   bool handMoveTo(double handPose);
   bool handSetForce(double handForce);
   bool handSetSpeed(double handSpeed);
+  bool handGripIn(double handForce);
+  bool handGripOut(double handForce);
   bool handGetPose(double &pose);
   bool handGetPressure(double &pressure);
   bool handIsCalibrated(double &handCalibrated);


### PR DESCRIPTION
If you do not specify a hand force for `Hand_GripIn` and `HandGripOut`RAPID will use the default value of 20 N. Therefore, the reason it seemed like `Hand_SetForce` was broken was because the default values of GripIn and GripOut where overriding it. Now GripIn and GripOut take `handForce` as an argument, allowing you to specify the gripping force. 

@nikhilcd This should resolve the issue you were seeing. 